### PR TITLE
fix(pace-caret): Fixed the last pace caret on repeated test (toma-demagn)

### DIFF
--- a/frontend/src/ts/test/pace-caret.ts
+++ b/frontend/src/ts/test/pace-caret.ts
@@ -23,7 +23,9 @@ export let settings: Settings | null = null;
 let lastTestWpm = 0;
 
 export function setLastTestWpm(wpm: number): void {
-  lastTestWpm = wpm;
+  if (!TestState.isPaceRepeat || TestState.isPaceRepeat && wpm > lastTestWpm) {
+    lastTestWpm = wpm;
+  }
 }
 
 function resetCaretPosition(): void {


### PR DESCRIPTION
Changed the logic for lastTestWpm when repeating a test

### Description

The last test WPM in a repeated test will be overriden only if the current WPM is greater than it.
This way, if we're repeating a test over and over again, we can compare our pace with the best pace we did on that specific test.

### Checks

- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside round brackets at the end of the PR title

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

Closes #

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
